### PR TITLE
Removed appRoot line in amplify file

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -25,4 +25,3 @@ applications:
       cache:
         paths:
           - node_modules/**/*
-    appRoot: frontend


### PR DESCRIPTION
The approot line was removed in the amplify file since now we don't have the frontend folder