### PR TITLE
Fixed a problem in reverse pagination

### DIFF
--- a/src/views/gallery.js
+++ b/src/views/gallery.js
@@ -201,8 +201,8 @@ function LightEcommerceA() {
           setHasData(true)
           if(nft_total_supply<=Landing.tokensPerPageNear){
             let payload = {
-              from_index: 0,
-              limit: nft_total_supply,
+              from_index: (0).toString(),
+              limit: parseInt(nft_total_supply),
             }
             setIndex(0)
             let toks = await contract.nft_tokens(


### PR DESCRIPTION
When testing the contract with the changes of the creator, it was possible to see a problem in the first call when the tokens were obtained when these were a smaller number than those that are usually brought per page, this error has already been resolved