### PR TITLE
Changed the price variable in the detail of an NFT for sale

### DIFF
--- a/src/views/Detail.view.js
+++ b/src/views/Detail.view.js
@@ -137,7 +137,7 @@ function LightEcommerceB(props) {
       nft_contract_token : process.env.REACT_APP_CONTRACT+"."+tokenID
     }
     let extData = await ext_view(process.env.REACT_APP_CONTRACT_MARKET,"get_sale",extPayload)
-    return fromYoctoToNear(extData.sale_conditions)
+    return fromYoctoToNear(extData.price)
   }
 
   async function manageOffer(option){


### PR DESCRIPTION
This error originated because the name of the price variable in the sales structure was changed, the name of the variable was changed.