### PR TITLE
Hotfix Route Create Collection

### DIFF
--- a/src/components/addTokenModal.component.js
+++ b/src/components/addTokenModal.component.js
@@ -229,7 +229,7 @@ export default function AddTokenModal(props) {
                   <>
                     <div className="flex flex-col justify-center">
                       <h1 className="text-darkgray text-xl text-center font-raleway mb-4">{t('addToken.msgNoCol')}</h1>
-                      <a className="bg-yellow2 mt-3 text-center items-center text-white active:bg-brown font-bold uppercase text-sm px-6 py-3 rounded-full shadow hover:shadow-lg outline-none focus:outline-none  ease-linear transition-all duration-150" href="/collection">{t('addToken.btnCol')}</a>
+                      <a className="bg-yellow2 mt-3 text-center items-center text-white active:bg-brown font-bold uppercase text-sm px-6 py-3 rounded-full shadow hover:shadow-lg outline-none focus:outline-none  ease-linear transition-all duration-150" href="/createCollection">{t('addToken.btnCol')}</a>
                     </div>
                   </>
                 }


### PR DESCRIPTION
An error was found in a route within the modal to add an NFT to a collection, when pressing the button to go to create a new collection, it sent to a non-existent route, the error was corrected and it now redirects to the correct route