### PR TITLE
Hotfix, confusion when adding token to a collection

### DIFF
--- a/src/components/addTokenModal.component.js
+++ b/src/components/addTokenModal.component.js
@@ -209,7 +209,7 @@ export default function AddTokenModal(props) {
                       <option key={0} value={-1}>{t('addToken.comboOpc')}</option>
                       {collectionData.length > 0 ?
                         collectionData.map((data) =>
-                          <option key={data.id} value={data.id}>{data.title}</option>
+                          <option key={data.id} value={data.id}>{data.title} - ID:{data.id}</option>
                         )
                         :
                         null}


### PR DESCRIPTION
The text shown in the modal to add the token to a collection was modified, when a collection has exactly the same name it is not possible to distinguish between the collections, generating the problem that tokens can be added to an incorrect collection, to solve this error added collection ID to display text so that one collection can be distinguished from another