### PR TITLE
Upload Nativo NFT images to IPFS via Pinata

### DIFF
--- a/src/utils/pinata.js
+++ b/src/utils/pinata.js
@@ -1,0 +1,24 @@
+var axios = require('axios');
+var FormData = require('form-data');
+
+export const uploadFileAPI = async (file) => {
+    try{
+        const formData = new FormData()
+        formData.append("file", file)
+        const resFile = await axios({
+            method: "post",
+            url: "https://api.pinata.cloud/pinning/pinFileToIPFS",
+            data: formData,
+            headers: {
+                'pinata_api_key': `${process.env.REACT_APP_PINATA_API_KEY}`,
+                'pinata_secret_api_key': `${process.env.REACT_APP_PINATA_API_SECRET}`,
+                "Content-Type": "multipart/form-data"
+            },
+        })
+        console.log(resFile)
+        return (resFile.data.IpfsHash)
+    } catch (error) {
+        console.log("Error sending File to IPFS: ")
+        console.log(error)
+    }
+}

--- a/src/views/createColl.js
+++ b/src/views/createColl.js
@@ -28,6 +28,7 @@ import {
 } from "../utils/near_interaction";
 import { Reader, uploadFile } from '../utils/fleek';
 import { Reader2, uploadFile2 } from '../utils/fleek2';
+import { uploadFileAPI } from '../utils/pinata'
 import Swal from 'sweetalert2'
 import { useTranslation } from "react-i18next";
 
@@ -163,6 +164,29 @@ function LightHeroE(props) {
    * cada vez que el usuario cambia de archivo se ejecuta esta funcion
    *
    */
+
+  async function uploadIconPinata(picture){
+    setTxtBttnIcon(t("CreateCol.btnImg-2"))
+    let file = picture.pop()
+    let cid = await uploadFileAPI(file)
+    setmint({ ...mint, fileIcon: URL.createObjectURL(file) });
+    formik.setFieldValue("image", cid);
+    setMediaIcon(cid)
+    setTxtBttnIcon(t("CreateCol.btnImg-3"))
+    console.log(cid)
+  }
+
+  async function uploadBannerPinata(picture){
+    setTxtBttnBanner(t("CreateCol.btnImg-2"))
+    let file = picture.pop()
+    let cid = await uploadFileAPI(file)
+    setmint({ ...mint, fileBanner: URL.createObjectURL(file) });
+    formik.setFieldValue("image", cid);
+    setMediaBanner(cid)
+    setTxtBttnBanner(t("CreateCol.btnImg-3"))
+    console.log(cid)
+  }
+
   function imageChangeIcon(picture) {
     setTxtBttnIcon(t("CreateCol.btnImg-2"))
     let data = picture.pop()
@@ -307,7 +331,7 @@ function LightHeroE(props) {
                       withIcon={false}
                       buttonText={txtBttnIcon}
                       buttonClassName="yellow-button"
-                      onChange={imageChangeIcon}
+                      onChange={uploadIconPinata}
                       imgExtension={['.jpg', '.gif', '.png', '.gif', '.jpeg', '.webp']}
                       maxFileSize={5242880}
                       singleImage={true}
@@ -328,7 +352,7 @@ function LightHeroE(props) {
                       withIcon={false}
                       buttonText={txtBttnBanner}
                       buttonClassName="yellow-button"
-                      onChange={imageChangeBanner}
+                      onChange={uploadBannerPinata}
                       imgExtension={['.jpg', '.gif', '.png', '.gif', '.jpeg', '.webp']}
                       maxFileSize={10485760}
                       singleImage={true}

--- a/src/views/mintNft.view.js
+++ b/src/views/mintNft.view.js
@@ -25,6 +25,7 @@ import {
   storage_byte_cost,
 } from "../utils/near_interaction";
 import { Reader, uploadFile } from '../utils/fleek';
+import { uploadFileAPI } from '../utils/pinata'
 import Swal from 'sweetalert2'
 import { useTranslation } from "react-i18next";
 import trashIcon from '../assets/img/bin.png';
@@ -303,6 +304,15 @@ function LightHeroE(props) {
    * cada vez que el usuario cambia de archivo se ejecuta esta funcion
    *
    */
+
+  async function uploadFilePinata(e){
+    let file = e.target.files[0]
+    setmint({ ...mint, file: URL.createObjectURL(e.target.files[0]) });
+    let cid = await uploadFileAPI(file)
+    formik.setFieldValue("image", cid);
+    console.log(cid)
+  }
+
   function imageChange(e) {
     const { file, reader } = Reader(e);
 
@@ -379,7 +389,7 @@ function LightHeroE(props) {
                     <img src={uploadImg} className="h-[150px] lg:h-[250px] object-contain"></img><span className="text-sm">{t("MintNFT.upImg")}</span></div>}
                   </div>
                   <input
-                    onChange={imageChange}
+                    onChange={uploadFilePinata}
                     onClick={imageClick}
                     type="file"
                     id="image"


### PR DESCRIPTION
To carry out this process, the pinata.js file was generated, which contains the function with the necessary information to be able to upload a file to IPFS through pinata, this process is being carried out through the use of its API since it is the easiest way to implement it. .

Also all the methods to upload images to IPFS that were using Fleek were changed for the new ones that were generated that make use of the Pinata API.
