### PR TITLE
Added a parameter when creating collection

### DIFF
--- a/src/views/createColl.js
+++ b/src/views/createColl.js
@@ -176,6 +176,7 @@ function LightHeroE(props) {
         media_icon: mediaIcon,
         media_banner: mediaBanner,
         visibility: visibility,
+        _id: "0",
         _type: "create"
       }
     }


### PR DESCRIPTION
The _id parameter was added in the create collection method since it's necessary in the edit version of the same method, we send a 0 since we do not use the data in the create part but it's necessary to send the parameter