### PR TITLE
Redirect button market

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ node_modules
 yarn.lock
 build
 .env.local
-
+package-lock.json
 src/tailwind.output.css

--- a/src/components/Hero.component.js
+++ b/src/components/Hero.component.js
@@ -20,7 +20,7 @@ function LightHeroE(props) {
             {t("Landing.subtitle")}
           </p>
           <div className="flex justify-between z-20">
-            <Link to="/gallery">
+            <Link to="/market">
               <button className="flex inline-flex rounded-xlarge w-full h-[50px]  mt-0 bg-gradient-to-b p-[7px] from-yellow  to-brown hover:shadow-brown-s customHover" >
                 <div className="flex inline-flex  w-full h-full text-white  text-center rounded-xlarge justify-center shadow-s">
                   <div className="flex flex-col font-bold h-full text-white  text-center rounded-xlarge justify-center shadow-s w-full">


### PR DESCRIPTION
The address route of the explore button that was on the landing page was updated, now instead of directing you to gallery, it directs you to market.

Added package-lock.json to gitignore to avoid problems with package versions.