### PR TITLE
My NFTs bug resolved

### DIFF
--- a/src/views/MisTokens.view.js
+++ b/src/views/MisTokens.view.js
@@ -844,21 +844,27 @@ function MisTokens(props) {
       const nft_payload = btoa(JSON.stringify(payload))
       const { network } = selector.options;
       const provider = new providers.JsonRpcProvider({ url: network.nodeUrl });
-      const res = await provider.query({
-        request_type: "call_function",
-        account_id: contract,
-        method_name: "nft_tokens_for_owner",
-        args_base64: nft_payload,
-        finality: "optimistic",
-      })
-      let nfts = JSON.parse(Buffer.from(res.result).toString())
-
-      let obj = {
-        contract : contract,
-        contractNfts: nfts
+      try{
+        const res = await provider.query({
+          request_type: "call_function",
+          account_id: contract,
+          method_name: "nft_tokens_for_owner",
+          args_base64: nft_payload,
+          finality: "optimistic",
+        })
+        let nfts = JSON.parse(Buffer.from(res.result).toString())
+  
+        let obj = {
+          contract : contract,
+          contractNfts: nfts
+        }
+  
+        allNfts.push(obj);
       }
-
-      allNfts.push(obj);
+      catch(err){
+        console.log(err)
+      }
+      
     }
 
     setAllNfts({nfts: allNfts, contracts: contracts});


### PR DESCRIPTION
The bug was triggered by 3 possible cases: 

- A contract with a broken state, 
- A deleted contract, 
- A contract without the nft_tokens_for_owner method.

With these cases it was possible that the loading of information was interrupted by the error when executing the query.
The error was resolved by adding a try catch so that if the error exists, its execution doesn't affect the rest

Note: Amplify is not configured in mainnet to create the environments of all the branches that are created as in testnet, there is no link to be able to test the branch in mainnet