### PR TITLE
Added support to Here Wallet

### DIFF
--- a/src/utils/walletSelector.jsx
+++ b/src/utils/walletSelector.jsx
@@ -26,7 +26,7 @@ export const WalletSelectorContextProvider = ({ children }) => {
                 setupNearWallet(),
                 setupMyNearWallet(),
                 //setupSender(),
-                //setupHereWallet(),
+                setupHereWallet(),
                 // setupMathWallet(),
                 // setupNightly(),
                 setupMeteorWallet(),


### PR DESCRIPTION
Support for Here wallet has been added through its connection with wallet selector, this wallet is only compatible (at the moment) with IOS.